### PR TITLE
fix: remove QA sign-off from GitHub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug.md
@@ -17,7 +17,6 @@
 
 ### Pre-Merge Checklist [PR Author]:
 
-- [ ] QA Sign-off [@gh-username]
 - [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 
 ### Reviewer Checklist [PR Reviewer]:

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -13,7 +13,6 @@
 
 ### Pre-Merge checklist [PR Author]:
 
-- [ ] QA Sign-off [@gh-username]
 - [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 - [ ] Database migrations have been run
 


### PR DESCRIPTION
### Jira Link: [DEVOPS-52](https://zeniuseducation.atlassian.net/browse/DEVOPS-52)

### Steps to Reproduce [PR Author]:

{Please provide the steps to reproduce the bug}

### Triage and Solution Proposed [PR Author]:

{Please provide a short text about the traige process conducted and the solution proposed to fix the bug}

### Self Review Checklist [PR Author]:

- [ ] If the bug could have been caught by adding an unit test, the test is now added
- [ ] If the bug could have been caught by adding an e2e test, the test is now added
- [x] Self reviewed code after raising the PR
- [x] Any hacks/workarounds added by the PR are called out via comments and appropriate reason is documented

### Pre-Merge Checklist [PR Author]:

- [ ] QA Sign-off [@gh-username]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

### Reviewer Checklist [PR Reviewer]:

- [ ] Jira Id is tagged and correct
- [ ] If possible, unit test is adeded to prevent similar bugs in future
- [ ] If possible, e2e test is added to prevent similar bugs in future
